### PR TITLE
fix: add error callback to zip-browser's zip.createReader.

### DIFF
--- a/zip-browser.js
+++ b/zip-browser.js
@@ -76,7 +76,7 @@ Unzip.prototype.getEntries = function (callback) {
     zipReader.getEntries(function (entries) {
       callback(null, entries, entries.length);
     });
-  });
+  }, callback);
 };
 
 Unzip.getEntryData = function (entry, callback) {


### PR DESCRIPTION
解析异常文件（新建一个txt文件然后改为apk文件）时无法对错误进行处理，看了一下源码是因为`zip-browser.js`在使用zip.createReader(reader, callback, onerror)时没有传入错误处理函数onerror，因此使用了默认的错误处理函数 onerror_default

![image](https://user-images.githubusercontent.com/10976378/57501812-8ab5eb00-731b-11e9-81ee-9beae1c4bbb5.png)

![](https://user-images.githubusercontent.com/10346399/57444193-2561eb80-7282-11e9-94d4-1e8c65acfb42.png)