### PR TITLE
fix: close zipFile

### DIFF
--- a/zip-node.js
+++ b/zip-node.js
@@ -77,6 +77,7 @@ Unzip.prototype.getBuffer = function (whatYouNeed, options, callback) {
         Unzip.getEntryData(zipfile, entry, function (error, buffer) {
           if (error) {
             callback(error);
+            zipfile.close();
             return;
           }
 
@@ -98,6 +99,7 @@ Unzip.prototype.getBuffer = function (whatYouNeed, options, callback) {
 
           if (finishedNumber >= whatYouNeed.length && !isMutiple) {
             callback(null, output, entryCount);
+            zipfile.close();
           } else {
             next();
           }

--- a/zip-node.js
+++ b/zip-node.js
@@ -35,6 +35,7 @@ Unzip.prototype.getEntries = function (callback, onEnd) {
       if (utils.isFunction(onEnd)) {
         onEnd();
       }
+      zipfile.close();
     });
 
     next();


### PR DESCRIPTION
According to the docs of `yauzl` (see [here](https://www.npmjs.com/package/yauzl#close)):

> If close() is never called, then the zipfile is "kept open". For zipfiles created with fromFd(), this will leave the fd open, which may be desirable. For zipfiles created with open(), this will leave the underlying fd open, thereby "leaking" it, which is probably undesirable. For zipfiles created with fromRandomAccessReader(), the reader's close() method will never be called. For zipfiles created with fromBuffer(), the close() function has no effect whether called or not.

We are using this lib in our application, and found the "leaking problems", which is likely caused by the unclose zipFile object.